### PR TITLE
update __init__.py for python3 compatibility

### DIFF
--- a/tsys01/__init__.py
+++ b/tsys01/__init__.py
@@ -1,1 +1,1 @@
-from tsys01 import TSYS01
+from .tsys01 import TSYS01


### PR DESCRIPTION
Fix #10 

This breaks python2 import statements though (don't know why):
```
Python 2.7.16 (default, Oct 10 2019, 22:02:15) 
[GCC 8.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import tsys01
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/pi/.local/lib/python2.7/site-packages/tsys01/__init__.py", line 1, in <module>
    from tsys01.tsys01 import TSYS01
ImportError: No module named tsys01
```